### PR TITLE
Added composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "cap60552/php-sip2",
+    "description": "PHP class library to facilitate communication with Integrated Library System (ILS) servers via 3M's SIP2.",
+    "authors": [
+        {
+            "name": "John Wohlers",
+            "email": "john@wohlershome.net",
+            "role": "Maintainer"
+        }
+    ],
+    "homepage": "https://github.com/cap60552/php-sip2",
+    "license": "GPL-3.0",
+    "support": {
+        "issues": "https://github.com/cap60552/php-sip2/issues"
+    },
+    "autoload": {
+        "classmap": ["/"]
+    }
+}
+


### PR DESCRIPTION
As recently discussed, this file should make it possible to easily include php-sip2 into a PHP project using Composer.

Once this is committed to master, you can make the package even more accessible by publishing it on Packagist. See "Publishing Packages" at https://packagist.org/. The site even has instructions on setting up a special GitHub hook that will automatically publish future releases as soon as they are tagged (and perhaps it's worth tagging the current version since it's been stable for a few years).

Please let me know if there's anything more I can do to help!
